### PR TITLE
Bump circleci openjdk image to 17 (#90)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     working_directory: ~/hawkBit-extensions
 
     docker:
-    - image: circleci/openjdk:11.0.13-jdk-buster
+    - image: cimg/openjdk:17.0.7
       auth:
         username: $DOCKERHUB_USER
         password: $DOCKERHUB_ACCESSTOKEN

--- a/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_23.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_23.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2023 Bosch.IO GmbH and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M8</version>
+      <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hawkbit-extensions-parent</artifactId>
@@ -40,7 +40,7 @@
     </distributionManagement>
 
    <properties>
-      <hawkbit.version>0.3.0M8</hawkbit.version>
+      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       <aws.sdk.version>1.12.400</aws.sdk.version>
       <gcp.sdk.version>0.77.0-alpha</gcp.sdk.version>
 


### PR DESCRIPTION
* Bump circleci openjdk image to 17



* deprecated circleci image to cimg



* add license template



* Refer latest hawkbit snapshot


---------